### PR TITLE
fix command status reporting

### DIFF
--- a/lib/util/git.js
+++ b/lib/util/git.js
@@ -79,17 +79,14 @@ exports.refresh = function(repo, url, remote, branch, callback) {
 
 
 exports.hasChanges = function(repo, callback) {
-  // When this succeeds but there are changes, it silently exits with code 1
-  gitd(repo, ['diff-index', '--quiet', 'HEAD', '--'], function(err) {
+  // This diff-index command lists any files that have been staged for commit. If none have been staged, it'll return an
+  // empty string, other than possibly whitespace.
+  gitd(repo, ['diff-index', 'HEAD', '--'], function(err, stdout) {
     if (err) {
-      if (err.message.indexOf('\nstderr:\n\nstdout:\n') < 0) {
-        callback(err);
-      } else {
-        callback(null, true);
-      }
-    } else {
-      callback(null, false);
+      callback(err);
+      return;
     }
+    callback(null, stdout.trim().length !== 0);
   });
 };
 

--- a/lib/util/misc.js
+++ b/lib/util/misc.js
@@ -69,22 +69,30 @@ exports.spawn = function(cmd, spawnOpts, callback) {
   });
 
   function closingEvent() {
-    if ((stdoutClosed && stderrClosed && typeof exitCode !== 'undefined') || timedOut) {
+    // If streams are closed and we have an exit code, the process finished. If the deadline passed, we're timing it
+    // out. If neither is true, do nothing and wait for another call to this function.
+    if ((stdoutClosed && stderrClosed && exitCode !== undefined) || timedOut) {
       clearTimeout(deadline);
-      log.info('Command failed', {
-        'cmd': cmdStr,
-        'code': exitCode || null,
-        'stdout': resultString || null,
-        'stderr': errString || null,
-        'timedOut': timedOut
-      });
 
-      var err;
-      if (exitCode) {
-        err = new Error(sprintf('Failed command %s:\nstderr:\n%s\nstdout:\n%s', cmdStr, errString, resultString));
-      } else if (timedOut) {
-        err = new Error(sprintf('Failed command %s: Timedout', cmdStr));
+      var message, err;
+      if (timedOut) {
+        err = new Error('Command timed out');
+      } else if (exitCode !== 0) {
+        err = new Error(sprintf('Command exited with status %s', exitCode));
       }
+      if (err) {
+        message = 'Command failed';
+      } else {
+        message = 'Command succeeded';
+      }
+
+      log.info(message, {
+        'cmd': cmdStr,
+        'code': exitCode,
+        'stdout': resultString,
+        'stderr': errString,
+        'timedOut': timedOut,
+      });
 
       callback(err, resultString, errString);
     }


### PR DESCRIPTION
A while back in history, somebody butchered this function while adding
the timeout feature. It always reports that the command failed in the
logs, and it spews a bunch of redundant data into the dreadnot
console. This fixes it to output correct and consistent information in
both the logs and the console. The stdout and stderr of the process is
already shown in the console. There's no need to include it in an
error here.

The git.hasChanges util function was hooked into the error message
format to detect whether there were changes or not. It seems a strange
way to check for changes. This also fixes that function to simply look
for output from the command.